### PR TITLE
media-sound/lmms-9999-r1: fixed installation of documentation

### DIFF
--- a/media-sound/lmms/lmms-9999-r1.ebuild
+++ b/media-sound/lmms/lmms-9999-r1.ebuild
@@ -34,7 +34,7 @@ RDEPEND="dev-qt/qtcore
 	vst? ( app-emulation/wine )"
 DEPEND="${RDEPEND}"
 
-DOCS=( README AUTHORS TODO )
+DOCS=( README.md )
 
 src_configure() {
 	mycmakeargs=(


### PR DESCRIPTION
the original files do not exist anymore